### PR TITLE
Add Slack webhook notifications for newly found buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ If you provide AWS access and secret keys in `config.yaml` Bucket Stream will at
                            Encrypt CA (default: False)
       -t , --threads       Number of threads to spawn. More threads = more power.
                            (default: 20)
+      -s , --slack         Send found buckets to a Slack channel via Webhook.
+                           Configure in config.yaml (default: False)
 
 ## F.A.Qs
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,3 @@
 aws_access_key: ''
 aws_secret: ''
+slack_webhook: ''


### PR DESCRIPTION
Added the ability to dump all newly found buckets to a Slack channel for easy access to new buckets for a remote/headless instance of bucket-stream.