### PR TITLE
Add initial Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3
+MAINTAINER Dave (Daviey) Walker <email@daviey.com>
+
+WORKDIR /opt
+
+COPY *.py *.yaml *.txt /opt/
+COPY requirements.txt /opt/
+
+RUN pip3 install -r /opt/requirements.txt
+
+ENTRYPOINT ["/usr/local/bin/python", "bucket-stream.py"]
+


### PR DESCRIPTION
This change adds a simple Dockerfile and can be built with:
$ docker build -t <namespace>/bucket-stream .

It can be run with:
$ docker run -t <namespace>/bucket-stream -h

To add AWS credentials, add to the config file and add
"-v config.yaml:/opt/config.yaml" to docker run.

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>