### PR TITLE
Typo in FOUND_COUNT

### DIFF
--- a/bucket-stream.py
+++ b/bucket-stream.py
@@ -20,7 +20,7 @@ UPDATE_INTERVAL = CONFIG['update_interval']  # seconds
 RATE_LIMIT_SLEEP = CONFIG['rate_limit_sleep']  # seconds
 
 CHECKED_BUCKETS = list()
-FUND_COUNT = 0
+FOUND_COUNT = 0
 
 
 class UpdateThread(Thread):


### PR DESCRIPTION
Typo resulting in an error being thrown on first bucket found.